### PR TITLE
v2

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,36 +17,26 @@ $ composer require digitallyhappy/assets
 
 ## Usage
 
-Replace your standard CSS and JS loading HTML with the `@asset()` Blade directive this package provides:
+Replace your standard CSS and JS loading HTML with the `@loadOnce()` Blade directive this package provides:
 
 ```diff
 -    <script src="{{ asset('path/to/file.js') }}">
-+    @asset('path/to/file.js')
++    @loadOnce('path/to/file.js')
 
 -    <link href="{{ asset('path/to/file.css') }}" rel="stylesheet" type="text/css">
-+    @asset('path/to/file.css')
++    @loadOnce('path/to/file.css')
 ```
 
-At this moment, the package provides a few Blade directives:
+The package provides three Blade directives, in 99% of the cases you'll use `@loadOnce()`:
 
 ```php
-@asset('path/to/file.css')
-@asset('path/to/file.js')
+@loadOnce('path/to/file.css')
+@loadOnce('path/to/file.js')
 // depending of the file extension, the first time it will output
 // <link href="{{ asset('path/to/file.css')" rel="stylesheet" type="text/css">
 // or
 // <script src="{{ asset('path/to/file.js')"></script>
 // then the rest of the times this is called... it'll output nothing
-
-// ALTERNATIVELY, if prefer to specify the type of file (CSS/JS) you can call:
-
-@loadCssOnce('path/to/file.css')
-// will output <link href="{{ asset('path/to/file.css')"> the first time
-// then the second time this is called it'll output nothing
-
-@loadJsOnce('path/to/file.js')
-// will output <script src="{{ asset('path/to/file.js')"></script> the first time
-// then the second time this is called it'll output nothing
 
 // IN ADDITION, if you have an entire block of HTML that you want to only output once:
 
@@ -63,6 +53,23 @@ At this moment, the package provides a few Blade directives:
 @endLoadOnce
 // will output the contents the first time...
 // then the second time it will just output nothing
+```
+
+However, if you want to pass a _variable_ as the parameter, not a _string_, you'll notice it won't work, because the directive can't tell if it's a CSS, JS or code block. That's why we've created `@loadStyleOnce()` and `@loadScriptOnce()`:
+
+```php
+@php
+    $pathToCssFile = 'path/to/file.css';
+    $pathToJsFile = 'path/to/file.js';
+@endphp
+
+@loadStyleOnce($pathToCssFile)
+// will output <link href="{{ asset('path/to/file.css')"> the first time
+// then the second time this is called it'll output nothing
+
+@loadScriptOnce($pathToJsFile)
+// will output <script src="{{ asset('path/to/file.js')"></script> the first time
+// then the second time this is called it'll output nothing
 ```
 
 ## Why does this package exist?

--- a/src/blade_directives.php
+++ b/src/blade_directives.php
@@ -12,13 +12,14 @@ Blade::directive('loadScriptOnce', function ($parameter) {
 
 Blade::directive('loadOnce', function ($parameter) {
     // determine if it's a CSS or JS file
-    $filePath = $parameter;
-    $filePath = trim($filePath, "'");
-    $filePath = trim($filePath, '"');
-    $filePath = trim($filePath, '`');
-    $filePath = Str::before($filePath, '?');
-    $filePath = Str::before($filePath, '#');
+    $cleanParameter = Str::of($parameter)->trim("'")->trim('"')->trim('`');
+    $filePath = Str::of($cleanParameter)->before('?')->before('#');
     $extension = substr($filePath, -3);
+
+    // mey be useful to get the second parameter
+    // if (Str::contains($parameter, ',')) {
+    //     $secondParameter = Str::of($parameter)->after(',')->trim(' ');
+    // }
 
     switch ($extension) {
         case 'css':
@@ -31,11 +32,8 @@ Blade::directive('loadOnce', function ($parameter) {
 
         default:
             // it's a block start
-            $parameter = trim($parameter, "'");
-            $parameter = trim($parameter, '"');
-            $parameter = trim($parameter, '`');
 
-            return "<?php if(! Assets::isAssetLoaded('".$parameter."')) { Assets::markAssetAsLoaded('".$parameter."');  ?>";
+            return "<?php if(! Assets::isAssetLoaded('".$cleanParameter."')) { Assets::markAssetAsLoaded('".$cleanParameter."');  ?>";
             break;
     }
 });


### PR DESCRIPTION
Fixes #6 

This PR:
- removes the `@asset()` directive (name was too general)
- makes the `@loadOnce()` directive smarter, in that it can also do what `@asset()` did before (load one script, load one style or load code block)
- renames `@loadCssOnce()` to `@loadStyleOnce()` - still needed when parameter is a variable
- renames `@loadJsOnce()` to `@loadScriptOnce()` - still needed when parameter is a variable