### PR TITLE
load blade directives after resolving blade compiler

### DIFF
--- a/src/blade_directives.php
+++ b/src/blade_directives.php
@@ -1,37 +1,40 @@
 <?php
 
 use Illuminate\Support\Str;
+use Illuminate\View\Compilers\BladeCompiler;
 
-Blade::directive('loadStyleOnce', function ($parameter) {
-    return "<?php Assets::echoCss({$parameter}); ?>";
-});
-
-Blade::directive('loadScriptOnce', function ($parameter) {
-    return "<?php Assets::echoJs({$parameter}); ?>";
-});
-
-Blade::directive('loadOnce', function ($parameter) {
-    // determine if it's a CSS or JS file
-    $cleanParameter = Str::of($parameter)->trim("'")->trim('"')->trim('`');
-    $filePath = Str::of($cleanParameter)->before('?')->before('#');
-
-    // mey be useful to get the second parameter
-    // if (Str::contains($parameter, ',')) {
-    //     $secondParameter = Str::of($parameter)->after(',')->trim(' ');
-    // }
-
-    if (substr($filePath, -3) == '.js') {
-        return "<?php Assets::echoJs({$parameter}); ?>";
-    }
-
-    if (substr($filePath, -4) == '.css') {
+$this->app->afterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
+    $bladeCompiler->directive('loadStyleOnce', function ($parameter) {
         return "<?php Assets::echoCss({$parameter}); ?>";
-    }
+    });
 
-    // it's a block start
-    return "<?php if(! Assets::isLoaded('".$cleanParameter."')) { Assets::markAsLoaded('".$cleanParameter."');  ?>";
-});
+    $bladeCompiler->directive('loadScriptOnce', function ($parameter) {
+        return "<?php Assets::echoJs({$parameter}); ?>";
+    });
 
-Blade::directive('endLoadOnce', function () {
-    return '<?php } ?>';
+    $bladeCompiler->directive('loadOnce', function ($parameter) {
+        // determine if it's a CSS or JS file
+        $cleanParameter = Str::of($parameter)->trim("'")->trim('"')->trim('`');
+        $filePath = Str::of($cleanParameter)->before('?')->before('#');
+
+        // mey be useful to get the second parameter
+        // if (Str::contains($parameter, ',')) {
+        //     $secondParameter = Str::of($parameter)->after(',')->trim(' ');
+        // }
+
+        if (substr($filePath, -3) == '.js') {
+            return "<?php Assets::echoJs({$parameter}); ?>";
+        }
+
+        if (substr($filePath, -4) == '.css') {
+            return "<?php Assets::echoCss({$parameter}); ?>";
+        }
+
+        // it's a block start
+        return "<?php if(! Assets::isLoaded('".$cleanParameter."')) { Assets::markAsLoaded('".$cleanParameter."');  ?>";
+    });
+
+    $bladeCompiler->directive('endLoadOnce', function () {
+        return '<?php } ?>';
+    });
 });


### PR DESCRIPTION
Tries to fix the issue reported in https://github.com/Laravel-Backpack/CRUD/issues/4168 where the way we load blade directives stops OTHER packages from properly loading THEIR blade directives.

Inspiration for this PR came from:
- https://github.com/404labfr/laravel-impersonate/pull/25/files
- https://github.com/404labfr/laravel-impersonate/blob/master/src/ImpersonateServiceProvider.php#L72-L102

Note to self - it's possible that in packages that's the "proper" way to load Blade directives (not with `Blade::directive()` as you would do in a Laravel app). Otherwise if any package uses this method and is loaded AFTER our package, they won't have their directives loaded.